### PR TITLE
Remove mechanism for setting $GOPATH in /etc/profile.d

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,3 @@
   command: go get github.com/tools/godep
            creates={{ golang_path }}/bin/godep
   environment: env
-
-- name: Enable GOPATH on login
-  template: src=gopath.sh.j2 dest=/etc/profile.d/gopath.sh

--- a/templates/gopath.sh.j2
+++ b/templates/gopath.sh.j2
@@ -1,2 +1,0 @@
-export GOPATH={{ golang_path }}
-export PATH=$PATH:$GOPATH/bin


### PR DESCRIPTION
Setting `$GOPATH` via `/etc/profile.d` proved difficult to work around in a CI environment. For development, the default of `$GOPATH` == `$HOME` automatically adds `$HOME/bin` to `$PATH`, which is desirable.
