### PR TITLE
Add support for Ansible 2.0

### DIFF
--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,4 +1,9 @@
 ---
 - hosts: all
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "azavea.golang" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,14 @@
            dest=/usr/local/src/go{{ golang_version }}.{{ golang_os }}-{{ golang_arch }}.tar.gz
 
 - name: Extract and install Go
-  command: tar -C /usr/local -xzf /usr/local/src/go{{ golang_version }}.{{ golang_os }}-{{ golang_arch }}.tar.gz
-           creates=/usr/local/bin/go
+  unarchive: src=/usr/local/src/go{{ golang_version }}.{{ golang_os }}-{{ golang_arch }}.tar.gz
+             dest=/usr/local/
+             copy=no
 
 - name: Symlink Go into /usr/local/bin
-  file: src=/usr/local/go/bin/{{ item }} dest=/usr/local/bin/{{ item }} state=link
+  file: src="/usr/local/go/bin/{{ item }}"
+        dest="/usr/local/bin/{{ item }}"
+        state=link
   with_items:
     - go
     - godoc
@@ -17,4 +20,5 @@
 - name: Install Godep
   command: go get github.com/tools/godep
            creates={{ golang_path }}/bin/godep
-  environment: env
+  environment:
+    GOPATH: "{{ golang_path }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,0 @@
----
-env:
-  GOPATH: "{{ golang_path }}"


### PR DESCRIPTION
Use `unarchive` module instead of `command` with `tar`. In addition, replace the stray `env` variable with an inline `GOPATH` environment variable.

I also tested to confirm that this change is backwards compatible with Ansible 1.9.x.