### PR TITLE
Make use of YAML role specification format

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -8,7 +8,7 @@ if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
   !(File.directory?("roles/azavea.build-essential") || File.symlink?("roles/azavea.build-essential")) ||
   !(File.directory?("roles/azavea.git") || File.symlink?("roles/azavea.git")) ||
   !(File.directory?("roles/azavea.mercurial") || File.symlink?("roles/azavea.mercurial"))
-  system("ansible-galaxy install -r roles.txt -p roles")
+  system("ansible-galaxy install -r roles.yml -p roles")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,3 +1,0 @@
-azavea.build-essential,0.1.0
-azavea.git,0.1.0
-azavea.mercurial,0.1.0

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,6 @@
+- name: azavea.build-essential
+  version: 0.1.0
+- name: azavea.git
+  version: 0.1.0
+- name: azavea.mercurial
+  version: 0.1.0


### PR DESCRIPTION
The is an attempt to silence deprecation warnings in Ansible 2.0.

---

**Testing**

```bash
$ cd examples
$ rm -rf roles/azavea.build-essential roles/azavea.git roles/azavea.mercurial
$ vagrant destroy -f && vagrant up
```