### PR TITLE
Remove build-essential dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vagrant
-examples/roles/azavea.build-essential
+
 examples/roles/azavea.git
 examples/roles/azavea.mercurial

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -5,7 +5,6 @@ VAGRANTFILE_API_VERSION = "2"
 
 # Ensure role dependencies are in place
 if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
-  !(File.directory?("roles/azavea.build-essential") || File.symlink?("roles/azavea.build-essential")) ||
   !(File.directory?("roles/azavea.git") || File.symlink?("roles/azavea.git")) ||
   !(File.directory?("roles/azavea.mercurial") || File.symlink?("roles/azavea.mercurial"))
   system("ansible-galaxy install -r roles.yml -p roles")

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,5 +1,3 @@
-- name: azavea.build-essential
-  version: 0.1.0
 - name: azavea.git
   version: 0.1.0
 - name: azavea.mercurial

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,5 @@ galaxy_info:
   categories:
   - development
 dependencies:
-  - { role: "azavea.build-essential" }
   - { role: "azavea.git" }
   - { role: "azavea.mercurial" }


### PR DESCRIPTION
Unclear why this dependency remains. We pull down the Golang binaries, so no compilation is required. Tests continue to complete successfully without it present.

Resolves part of #6 
